### PR TITLE
Add support for GeoInterface CRS metadata

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -51,5 +51,9 @@ function read(fn::Union{AbstractString,Parquet2.FilePathsBase.AbstractPath,Parqu
     for column in keys(meta.columns)
         df[!, column] = GFT.WellKnownBinary.(Ref(GFT.Geom()), df[!, column])
     end
+    mc = meta.columns[meta.primary_column]
+    if !isnothing(mc.crs)
+        metadata!(df, "GEOINTERFACE:crs", mc.crs)
+    end
     df
 end

--- a/src/io.jl
+++ b/src/io.jl
@@ -48,12 +48,15 @@ function read(fn::Union{AbstractString,Parquet2.FilePathsBase.AbstractPath,Parqu
     is_valid(ds) || error("Not a valid GeoParquet file")
     meta = geometadata(ds)
     df = DataFrame(ds; copycols=false)
-    for column in keys(meta.columns)
+    geocolumns = Symbol.(keys(meta.columns))
+    for column in geocolumns
         df[!, column] = GFT.WellKnownBinary.(Ref(GFT.Geom()), df[!, column])
     end
-    mc = meta.columns[meta.primary_column]
-    if !isnothing(mc.crs)
-        metadata!(df, "GEOINTERFACE:crs", mc.crs)
+    # set GeoInterface metadata
+    metadata!(df, "GEOINTERFACE:geometrycolumns", geocolumns)
+    crs = meta.columns[meta.primary_column].crs
+    if !isnothing(crs)
+        metadata!(df, "GEOINTERFACE:crs", crs)
     end
     df
 end

--- a/src/io.jl
+++ b/src/io.jl
@@ -48,12 +48,11 @@ function read(fn::Union{AbstractString,Parquet2.FilePathsBase.AbstractPath,Parqu
     is_valid(ds) || error("Not a valid GeoParquet file")
     meta = geometadata(ds)
     df = DataFrame(ds; copycols=false)
-    geocolumns = Symbol.(keys(meta.columns))
-    for column in geocolumns
+    for column in keys(meta.columns)
         df[!, column] = GFT.WellKnownBinary.(Ref(GFT.Geom()), df[!, column])
     end
     # set GeoInterface metadata
-    metadata!(df, "GEOINTERFACE:geometrycolumns", geocolumns)
+    metadata!(df, "GEOINTERFACE:geometrycolumns", Tuple(Symbol.(keys(meta.columns))))
     crs = meta.columns[meta.primary_column].crs
     if !isnothing(crs)
         metadata!(df, "GEOINTERFACE:crs", crs)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,9 @@ end
         df = GeoParquet.read(fn)
         @test nrow(df) === 5
         @test df.geometry[1] isa GFT.WellKnownBinary
+        # GeoInterface metadata
+        @test metadata(df, "GEOINTERFACE:geometrycolumns") == (:geometry,)
+        @test metadata(df, "GEOINTERFACE:crs") isa GFT.ProjJSON
 
         @test_throws Exception GeoParquet.read(fn, columns=(:geom,))
     end


### PR DESCRIPTION
Waiting for https://github.com/JuliaGeo/GeoInterface.jl/pull/161
Closes #24 

Test code:
```julia
julia> using GeoParquet, DataFrames

julia> df = GeoParquet.read("example.parquet")
5×6 DataFrame
 Row │ pop_est         continent      name                      iso_a3   gdp_md_est  geometry                          
     │ Float64?        String?        String?                   String?  Int64?      WellKnow…                         
─────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1 │ 889953.0        Oceania        Fiji                      FJI            5496  WellKnownBinary{Geom, Vector{UIn…
  ⋮  │       ⋮               ⋮                   ⋮                 ⋮         ⋮                       ⋮
                                                                                                         4 rows omitted

julia> metadata(df, "GEOINTERFACE:geometrycolumns")
(:geometry,)

julia> metadata(df, "GEOINTERFACE:crs")
GeoFormatTypes.ProjJSON(...)
```